### PR TITLE
chore: `crypto` is now a built-in Node module

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "homepage": "https://github.com/liuzemei/mixin-node-sdk#readme",
   "dependencies": {
     "axios": "^0.19.0",
-    "crypto": "^1.0.1",
     "int64-buffer": "^0.99.1007",
     "jsonwebtoken": "^8.5.1",
     "node-forge": "^0.9.1",


### PR DESCRIPTION
@liuzemei The npm package has been deprecated